### PR TITLE
LocalStatistics: correct variance calculation

### DIFF
--- a/muvsfunc.py
+++ b/muvsfunc.py
@@ -3689,7 +3689,8 @@ def LocalStatistics(clip, radius=1, **depth_args):
     clip = mvf.Depth(clip, depth=32, sample=vs.FLOAT, **depth_args)
 
     mean = Expectation(clip)
-    var = Expectation(core.std.Expr([clip, mean], ['x y - dup *']))
+    squared = Expectation(core.std.Expr(clip, 'x dup *'))
+    var = core.std.Expr([squared, mean], 'x y dup * -')
 
     return clip, mean, var
 


### PR DESCRIPTION
This calculates `Var(X) = E(X²) - E(X)²` instead of what I assume isn't a correct way of calculating variance since it includes means of other windows besides the current one.